### PR TITLE
Add possibility to build QmlVlc as QML plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 .DS_Store
+*.o
+*.so
+moc_*.cpp
+Makefile

--- a/QmlVlc.cpp
+++ b/QmlVlc.cpp
@@ -34,7 +34,7 @@
 #include "QmlVlcMmPlayer.h"
 #endif
 
-const char* qmlVlcUri = "QmlVlc";
+const char* qmlVlcUri = "rsatom.qml.vlc";
 const int QmlVlcVersionMajor = 0;
 const int QmlVlcVersionMinor = 1;
 

--- a/QmlVlcPlayer.cpp
+++ b/QmlVlcPlayer.cpp
@@ -34,6 +34,8 @@ QmlVlcPlayer::QmlVlcPlayer( QObject* parent )
     m_libvlc = QmlVlcConfig::instance().createLibvlcInstance();
     if( m_libvlc )
         player().open( m_libvlc );
+    else
+        qCritical("Couldn't create libvlc instance. Check vlc plugins dir.");
 }
 
 QmlVlcPlayer::~QmlVlcPlayer()

--- a/qmldir
+++ b/qmldir
@@ -1,0 +1,2 @@
+module rsatom.qml.vlc
+plugin qmlvlcplugin

--- a/qmlvlc.pro
+++ b/qmlvlc.pro
@@ -1,0 +1,22 @@
+include(QmlVlc.pri)
+
+CONFIG += c++11
+LIBS += -lvlc
+TARGET = qmlvlcplugin
+
+PLUGIN_IMPORT_PATH = rsatom/qml/vlc
+
+TEMPLATE = lib
+CONFIG += qt plugin
+QT += qml quick
+
+target.path = $$[QT_INSTALL_QML]/$$PLUGIN_IMPORT_PATH
+INSTALLS += target
+
+qmldir.files += $$_PRO_FILE_PWD_/qmldir
+qmldir.path += $$target.path
+INSTALLS += qmldir
+
+HEADERS += qmlvlc_plugin.h
+
+

--- a/qmlvlc_plugin.h
+++ b/qmlvlc_plugin.h
@@ -1,0 +1,21 @@
+#pragma once 
+
+#include <QtQml>
+#include <QQmlExtensionPlugin>
+
+#include <QmlVlc.h>
+
+#define QMLVLC_PLUGIN_ID "rsatom.qml.vlc"
+
+class Q_DECL_EXPORT QmlVlcExtensionPlugin : public QQmlExtensionPlugin {
+    Q_OBJECT
+    Q_PLUGIN_METADATA(IID QMLVLC_PLUGIN_ID)
+
+    public:
+        virtual void initializeEngine(QQmlEngine *engine, const char *uri) {}
+        virtual void registerTypes(const char *uri) 
+        {
+            Q_ASSERT(QString(QMLVLC_PLUGIN_ID) == uri);
+            RegisterQmlVlc();
+        }
+};


### PR DESCRIPTION
QML plugins could be easily used with PyQt5 apps or
any other language bindings.

Build & Install QmlVlc as plugin:
qmake && make && make install

More info about Qt QML plugins:
http://doc.qt.io/qt-5/qtqml-modules-cppplugins.html