### PR TITLE
Adds the QmlVlcPlaylist :: add (Qurl) method  for direct use of the Qurl object.

### DIFF
--- a/QmlVlcPlaylist.cpp
+++ b/QmlVlcPlaylist.cpp
@@ -110,6 +110,11 @@ int QmlVlcPlaylist::add( const QString& mrl )
     return player().add_media( mrl.toUtf8().data() );
 }
 
+int QmlVlcPlaylist::add(const QUrl &mrl)
+{
+    return player().add_media( mrl.toString().toUtf8().data() );
+}
+
 int QmlVlcPlaylist::add( QmlVlcMedia* media )
 {
     if( !media )

--- a/QmlVlcPlaylist.h
+++ b/QmlVlcPlaylist.h
@@ -68,6 +68,7 @@ public:
     ItemsProperty_t get_items();
 
     Q_INVOKABLE int add( const QString& mrl );
+    Q_INVOKABLE int add( const QUrl& mrl );
     Q_INVOKABLE int add( QmlVlcMedia* media );
     Q_INVOKABLE int addWithOptions( const QString& mrl, const QStringList& options );
 


### PR DESCRIPTION
It took a while before I realized that you must make more than just get the file path.

And now I do not have to write:

    `VlcPlayer.playlist.add` (fileDialog.fileUrl.toString ())`

Just take it:

    `VlcPlayer.playlist.add (fileDialog.fileUrl)`